### PR TITLE
add ncnn package

### DIFF
--- a/ai/ncnn/Kconfig
+++ b/ai/ncnn/Kconfig
@@ -1,0 +1,32 @@
+
+# Kconfig file for package ncnn
+menuconfig PKG_USING_NCNN
+    bool "Please add description of ncnn in English."
+    default n
+
+if PKG_USING_NCNN
+
+    config PKG_NCNN_PATH
+        string
+        default "/packages/ai/ncnn"
+
+    choice
+        prompt "Version"
+        default PKG_USING_NCNN_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_NCNN_V100
+            bool "v1.0.0"
+
+        config PKG_USING_NCNN_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_NCNN_VER
+       string
+       default "v1.0.0"    if PKG_USING_NCNN_V100
+       default "latest"    if PKG_USING_NCNN_LATEST_VERSION
+
+endif
+

--- a/ai/ncnn/package.json
+++ b/ai/ncnn/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "ncnn",
+  "description": "Please add description of ncnn in English.",
+  "description_zh": "请添加软件包 ncnn 的中文描述。",
+  "enable": "PKG_USING_NCNN",
+  "keywords": [
+    "ncnn"
+  ],
+  "category": "ai",
+  "author": {
+    "name": "yechang@rt-thread.com",
+    "email": "yechang@rt-thread.com",
+    "github": "yechang@rt-thread.com"
+  },
+  "license": "BSD-3-Clause",
+  "repository": "https://github.com/yc66542260/ncnn-rtthread",
+  "icon": "unknown",
+  "homepage": "https://github.com/yc66542260/ncnn-rtthread#readme",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "v1.0.0",
+      "URL": "https://github.com/yc66542260/ncnn-rtthread.git",
+      "filename": "ncnn-rtthread-1.0.0.zip",
+	  "VER_SHA": "248489d0493304e41e4757c858609aa17c0e06fa"
+    },
+    {
+      "version": "latest",
+      "URL": "https://github.com/yc66542260/ncnn-rtthread.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
增加arm-a核的ncnn静态库支持，可以在rt-thread OS树莓派4B和rk3568上使用，进行AI推理。